### PR TITLE
Remove and replace the use of "theme" arg in mf_init()

### DIFF
--- a/vignettes/logo.Rmd
+++ b/vignettes/logo.Rmd
@@ -118,11 +118,9 @@ sfCarrLiss <- btb::kernelSmoothing(dfObservations = sample,
 
 ```{r}
 mf_theme(bg = "#FFFFFFFF")
-mf_init(x = hexagon)
- mf_map(x = hexagon, 
+mf_map(x = hexagon, 
         border="#7D0025",
-        col="#7D0025",
-        add = TRUE)
+        col="#7D0025")
  mf_map(x = hexagon_int, 
         border="#e8f4f8",
         col="#e8f4f8",

--- a/vignettes/logo.Rmd
+++ b/vignettes/logo.Rmd
@@ -117,8 +117,8 @@ sfCarrLiss <- btb::kernelSmoothing(dfObservations = sample,
 6. Plot the result with `mapsf` !
 
 ```{r}
-
-mf_init(x=hexagon,theme = mf_theme(list(bg = "#FFFFFFFF")))
+mf_theme(bg = "#FFFFFFFF")
+mf_init(x = hexagon)
  mf_map(x = hexagon, 
         border="#7D0025",
         col="#7D0025",


### PR DESCRIPTION
to accommodate a forthcoming release of mapsf that will remove the "theme" argument from the `mf_init()` function. 