### PR TITLE
Add RcppParallel cxxflags to makevars

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -9,4 +9,5 @@ SHLIB_CXX14LD = $(CXX14) $(CXX14STD)
 SHLIB_CXX14LDFLAGS = -shared
 
 PKG_CXXFLAGS = -DRCPP_PARALLEL_USE_TBB=1
+PKG_CXXFLAGS += $(shell ${R_HOME}/bin/Rscript -e "RcppParallel::CxxFlags()")
 PKG_LIBS = $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) `$(R_HOME)/bin/Rscript -e "RcppParallel::RcppParallelLibs()"`

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -9,4 +9,5 @@ SHLIB_CXX14LD = $(CXX14) $(CXX14STD)
 SHLIB_CXX14LDFLAGS = -shared
 
 PKG_CXXFLAGS = -DRCPP_PARALLEL_USE_TBB=1
+PKG_CXXFLAGS += $(shell "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" -e "RcppParallel::CxxFlags()")
 PKG_LIBS = $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) `$(R_HOME)/bin/Rscript -e "RcppParallel::RcppParallelLibs()"`


### PR DESCRIPTION
This PR updates your Makevars to add RcppParallel's CXXFLAGS, which will be needed for compatibility with Windows ARM64