### PR TITLE
Fix linking to RcppParallel libraries on Windows.

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -9,4 +9,4 @@ SHLIB_CXX14LD = $(CXX14) $(CXX14STD)
 SHLIB_CXX14LDFLAGS = -shared
 
 PKG_CXXFLAGS = -DRCPP_PARALLEL_USE_TBB=1
-PKG_LIBS = $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) `$(R_HOME)/bin/Rscript -e "RcppParallel::RcppParallelLibs()"`
+PKG_LIBS = $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::RcppParallelLibs()")


### PR DESCRIPTION
This fixes a linking failure on Windows due to accidental double quotes around the full path to RcppParallel, i.e.

```
cannot find -lRcppParallel: No such file or directory
```
as a result of 

```
-L"C:/r_packages/pkgbuild/lib/RcppParallel/libs/x64" -lRcppParallel
```
Generally, `$(shell)` is more reliable than backticks on Windows. 